### PR TITLE
Alterada validação para RJ

### DIFF
--- a/lib/br_inscricao_estadual/rj.rb
+++ b/lib/br_inscricao_estadual/rj.rb
@@ -1,6 +1,24 @@
 module BrInscricaoEstadual
 	class RJ < Common
+
+    def calculate_verify(peso)
+      result = calculate(peso)%11
+      digit_verify_inscription(result)
+    end
+
+    def digit_verify_inscription(result)
+      self.class::DIGITS_ZERO.include?(result) ? 0 : 11 - result
+    end
+
+    def digit_verify
+      digito = calculate_verify(self.class::PESO)
+      return false unless self.insc_est[(self.class::PESO.size)].to_i == digito
+
+      true
+    end
+
     protected
+      DIGITS_ZERO = [0, 1]
       PESO = [2, 7, 6, 5, 4, 3, 2]
       STATE_INSC_SIZE = 8
       

--- a/spec/br_inscricao_estadual/rj_spec.rb
+++ b/spec/br_inscricao_estadual/rj_spec.rb
@@ -5,8 +5,21 @@ describe BrInscricaoEstadual::RJ do
 
 	it "should valid Rio de Janeiro states incription" do
 		insc_est = BrInscricaoEstadual::RJ.new('99.999.99-3')
-		insc_est.should be_valid
+    insc_est.should be_valid
+
+    insc_est = BrInscricaoEstadual::Base.new('99.999.99-3', 'RJ')
+    insc_est.should be_valid
 	end
+
+  it "should valid Rio de Janeiro states incription" do
+    insc_est = BrInscricaoEstadual::RJ.new('87.350.71-1')
+    insc_est.should be_valid
+  end
+
+  it "should valid Rio de Janeiro states incription" do
+    insc_est = BrInscricaoEstadual::RJ.new('79.529.68.0')
+    insc_est.should be_valid
+  end
 
 	it "should not valid Rio de Janeiro states incription" do
 		insc_est = BrInscricaoEstadual::RJ.new('99.999.99-4')


### PR DESCRIPTION
Sobrescrevi o método de validação na classe específica para simplificar o código, seguindo as instruções do site do sintegra. Também adicionei alguns testes.